### PR TITLE
Add Error Indication to Secondaries

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
         minSdk 21
         targetSdk 34
 
-        versionCode 35
+        versionCode 37
 
         versionName "1.0.9"
 

--- a/app/src/main/java/com/paetus/animaCharCreator/activities/fragments/home_fragments/SecondaryAbilityFragment.kt
+++ b/app/src/main/java/com/paetus/animaCharCreator/activities/fragments/home_fragments/SecondaryAbilityFragment.kt
@@ -64,9 +64,9 @@ fun SecondaryAbilityFragment(
                     Text(text = stringResource(id = R.string.freelancerPrompt))
 
                     //freelancer bonus dropdowns
-                    secondaryFragVM.allFreelancerSelections.forEach{freeSelectionIten ->
+                    secondaryFragVM.allFreelancerSelections.forEach{freeSelectionItem ->
                         FreelancerDropdown(
-                            selection = freeSelectionIten,
+                            selection = freeSelectionItem,
                             secondaryFragVM = secondaryFragVM
                         )
                     }
@@ -325,7 +325,9 @@ private fun MakeRow(
                 }
                 .weight(0.15f),
             label = secondaryChar.dpDisplay.collectAsState().value,
-            postRun = {homePageVM.updateExpenditures()}
+            postRun = {homePageVM.updateExpenditures()},
+            isError = secondaryChar.pointInput.collectAsState().value != "" &&
+                    secondaryChar.pointInput.collectAsState().value.toInt() in 1..4
         )
 
         //display associated mod value

--- a/app/src/main/java/com/paetus/animaCharCreator/character_creation/attributes/combat/CombatAbilities.kt
+++ b/app/src/main/java/com/paetus/animaCharCreator/character_creation/attributes/combat/CombatAbilities.kt
@@ -157,7 +157,7 @@ class CombatAbilities(private val charInstance: BaseCharacter){
 
         //add together class level value, dexterity, agility, and special input
         totalInitiative.intValue =
-            classInitiative + charInstance.primaryList.dex.outputMod.intValue +
+            20 + classInitiative + charInstance.primaryList.dex.outputMod.intValue +
                     charInstance.primaryList.agi.outputMod.intValue + specInitiative.intValue
     }
 

--- a/app/src/main/java/com/paetus/animaCharCreator/composables/NumberInput.kt
+++ b/app/src/main/java/com/paetus/animaCharCreator/composables/NumberInput.kt
@@ -6,7 +6,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.input.KeyboardType
@@ -28,7 +27,6 @@ import androidx.compose.ui.text.style.TextAlign
  * @param alignment optional alignment for the input text
  * @param readOnly optional state of the text input
  */
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun NumberInput(
     inputText: String,


### PR DESCRIPTION
-indicate error in input for secondary investments worth less than 5 points -fix base initiative not being included before